### PR TITLE
Fix application.properties syntax issue

### DIFF
--- a/ftgo-accounting-service/src/main/resources/application.properties
+++ b/ftgo-accounting-service/src/main/resources/application.properties
@@ -8,10 +8,10 @@ logging.level.org.hibernate.SQL=DEBUG
 logging.level.io.eventuate=DEBUG
 logging.level.net.chrisrichardson.ftgo=DEBUG
 logging.level.io.eventuate.tram=DEBUG
-spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo_accounting_service
+spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:-localhost}/ftgo_accounting_service
 spring.datasource.username=ftgo_accounting_service_user
 spring.datasource.password=ftgo_accounting_service_password
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 
-eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:localhost}:9092
-eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:localhost}:2181
+eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:-localhost}:9092
+eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:-localhost}:2181

--- a/ftgo-consumer-service/src/main/resources/application.properties
+++ b/ftgo-consumer-service/src/main/resources/application.properties
@@ -8,10 +8,10 @@ logging.level.org.hibernate.SQL=DEBUG
 logging.level.io.eventuate=DEBUG
 logging.level.net.chrisrichardson.ftgo=DEBUG
 logging.level.io.eventuate.tram=DEBUG
-spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo_consumer_service
+spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:-localhost}/ftgo_consumer_service
 spring.datasource.username=ftgo_consumer_service_user
 spring.datasource.password=ftgo_consumer_service_password
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 
-eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:localhost}:9092
-eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:localhost}:2181
+eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:-localhost}:9092
+eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:-localhost}:2181

--- a/ftgo-delivery-service/src/main/resources/application.properties
+++ b/ftgo-delivery-service/src/main/resources/application.properties
@@ -14,10 +14,10 @@ logging.level.net.chrisrichardson.ftgo=DEBUG
 logging.level.io.eventuate.tram=DEBUG
 
 eventuate.database.schema=none
-spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo_delivery_service
+spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:-localhost}/ftgo_delivery_service
 spring.datasource.username=ftgo_delivery_service_user
 spring.datasource.password=ftgo_delivery_service_password
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 
-eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:localhost}:9092
-eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:localhost}:2181
+eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:-localhost}:9092
+eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:-localhost}:2181

--- a/ftgo-kitchen-service/src/main/resources/application.properties
+++ b/ftgo-kitchen-service/src/main/resources/application.properties
@@ -9,10 +9,10 @@ logging.level.io.eventuate=DEBUG
 logging.level.net.chrisrichardson.ftgo=DEBUG
 logging.level.io.eventuate.tram=DEBUG
 
-spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo_kitchen_service
+spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:-localhost}/ftgo_kitchen_service
 spring.datasource.username=ftgo_kitchen_service_user
 spring.datasource.password=ftgo_kitchen_service_password
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 
-eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:localhost}:9092
-eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:localhost}:2181
+eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:-localhost}:9092
+eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:-localhost}:2181

--- a/ftgo-kitchen-service/src/test/resources/application.properties
+++ b/ftgo-kitchen-service/src/test/resources/application.properties
@@ -5,16 +5,16 @@ spring.jpa.generate-ddl=true
 stubrunner.stream.enabled=false
 stubrunner.integration.enabled=false
 
-spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/eventuate
+spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:-localhost}/eventuate
 spring.datasource.username=mysqluser
 spring.datasource.password=mysqlpw
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.data.mongodb.uri=mongodb://${DOCKER_HOST_IP:localhost}/bankingexampledb
+spring.data.mongodb.uri=mongodb://${DOCKER_HOST_IP:-localhost}/bankingexampledb
 
-eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:localhost}:9092
-eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:localhost}:2181
+eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:-localhost}:9092
+eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:-localhost}:2181
 
 aws.access.key_id=id_key
 aws.secret.access.key=access_key
-aws.dynamodb.endpoint.url=http://${DOCKER_HOST_IP:localhost}:8000
+aws.dynamodb.endpoint.url=http://${DOCKER_HOST_IP:-localhost}:8000
 aws.region=us-west-2

--- a/ftgo-order-history-service/src/main/resources/application.properties
+++ b/ftgo-order-history-service/src/main/resources/application.properties
@@ -7,10 +7,10 @@ logging.level.net.chrisrichardson.ftgo=DEBUG
 logging.level.io.eventuate.tram=DEBUG
 logging.level.root=INFO
 
-eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:localhost}:9092
-eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:localhost}:2181
+eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:-localhost}:9092
+eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:-localhost}:2181
 
 aws.access.key_id=id_key
 aws.secret.access.key=access_key
-aws.dynamodb.endpoint.url=http://${DOCKER_HOST_IP:localhost}:8000
+aws.dynamodb.endpoint.url=http://${DOCKER_HOST_IP:-localhost}:8000
 aws.region=us-west-2

--- a/ftgo-order-history-service/src/test/resources/application.properties
+++ b/ftgo-order-history-service/src/test/resources/application.properties
@@ -5,16 +5,16 @@ spring.jpa.generate-ddl=true
 stubrunner.stream.enabled=false
 stubrunner.integration.enabled=false
 
-spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/eventuate
+spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:-localhost}/eventuate
 spring.datasource.username=mysqluser
 spring.datasource.password=mysqlpw
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.data.mongodb.uri=mongodb://${DOCKER_HOST_IP:localhost}/bankingexampledb
+spring.data.mongodb.uri=mongodb://${DOCKER_HOST_IP:-localhost}/bankingexampledb
 
-eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:localhost}:9092
-eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:localhost}:2181
+eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:-localhost}:9092
+eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:-localhost}:2181
 
 aws.access.key_id=id_key
 aws.secret.access.key=access_key
-aws.dynamodb.endpoint.url=http://${DOCKER_HOST_IP:localhost}:8000
+aws.dynamodb.endpoint.url=http://${DOCKER_HOST_IP:-localhost}:8000
 aws.region=us-west-2

--- a/ftgo-order-service/src/main/resources/application.properties
+++ b/ftgo-order-service/src/main/resources/application.properties
@@ -14,10 +14,10 @@ logging.level.net.chrisrichardson.ftgo=DEBUG
 logging.level.io.eventuate.tram=DEBUG
 
 eventuate.database.schema=none
-spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo_order_service
+spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:-localhost}/ftgo_order_service
 spring.datasource.username=ftgo_order_service_user
 spring.datasource.password=ftgo_order_service_password
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 
-eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:localhost}:9092
-eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:localhost}:2181
+eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:-localhost}:9092
+eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:-localhost}:2181

--- a/ftgo-restaurant-service-aws-lambda/src/main/resources/application.properties
+++ b/ftgo-restaurant-service-aws-lambda/src/main/resources/application.properties
@@ -1,15 +1,15 @@
 logging.level.org.springframework=INFO
 logging.level.org.springframework.jdbc.datasource.DataSourceUtils=DEBUG
 
-spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/eventuate
+spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:-localhost}/eventuate
 spring.datasource.username=mysqluser
 spring.datasource.password=mysqlpw
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 
-eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:localhost}:9092
-eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:localhost}:2181
+eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:-localhost}:9092
+eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:-localhost}:2181
 
 aws.access.key_id=id_key
 aws.secret.access.key=access_key
-aws.dynamodb.endpoint.url=http://${DOCKER_HOST_IP:localhost}:8000
+aws.dynamodb.endpoint.url=http://${DOCKER_HOST_IP:-localhost}:8000
 aws.region=us-west-2

--- a/ftgo-restaurant-service/src/main/resources/application.properties
+++ b/ftgo-restaurant-service/src/main/resources/application.properties
@@ -9,10 +9,10 @@ logging.level.io.eventuate=DEBUG
 logging.level.net.chrisrichardson.ftgo=DEBUG
 logging.level.io.eventuate.tram=DEBUG
 
-spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:localhost}/ftgo_restaurant_service
+spring.datasource.url=jdbc:mysql://${DOCKER_HOST_IP:-localhost}/ftgo_restaurant_service
 spring.datasource.username=ftgo_restaurant_service_user
 spring.datasource.password=ftgo_restaurant_service_password
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 
-eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:localhost}:9092
-eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:localhost}:2181
+eventuatelocal.kafka.bootstrap.servers=${DOCKER_HOST_IP:-localhost}:9092
+eventuatelocal.zookeeper.connection.string=${DOCKER_HOST_IP:-localhost}:2181


### PR DESCRIPTION
**ISSUE**

In application.properties the value of the variable 
_${DOCKER_HOST_IP:localhost}_
is supposed to be "localhost" in case DOCKER_HOST_IP is unset, but it isn't.

**FIX**

The correct syntax to do that is
_${DOCKER_HOST_IP:-localhost}_
with a "-" before localhost

https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html