### PR TITLE
Add support for Arm64

### DIFF
--- a/deployment/kubernetes/cdc-service/ftgo-cdc-service.yml
+++ b/deployment/kubernetes/cdc-service/ftgo-cdc-service.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     svc: ftgo-cdc-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-cdc-service
@@ -17,12 +17,17 @@ metadata:
     application: ftgo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ftgo-cdc-service
+      svc: ftgo-cdc-service
   strategy:
     rollingUpdate:
       maxUnavailable: 0
   template:
     metadata:
       labels:
+        app: ftgo-cdc-service
         svc: ftgo-cdc-service
     spec:
       containers:

--- a/deployment/kubernetes/scripts/kubernetes-deploy-all.sh
+++ b/deployment/kubernetes/scripts/kubernetes-deploy-all.sh
@@ -4,6 +4,6 @@ kubectl apply -f <(cat deployment/kubernetes/stateful-services/*.yml)
 
 ./deployment/kubernetes/scripts/kubernetes-wait-for-ready-pods.sh ftgo-mysql-0 ftgo-kafka-0 ftgo-dynamodb-local-0 ftgo-zookeeper-0
 
-kubectl apply -f <(cat deployment/kubernetes/cdc-services/*.yml)
+kubectl apply -f <(cat deployment/kubernetes/cdc-service/*.yml)
 
 kubectl apply -f <(cat */src/deployment/kubernetes/*.yml)

--- a/deployment/kubernetes/stateful-services/ftgo-dynamodb-local.yml
+++ b/deployment/kubernetes/stateful-services/ftgo-dynamodb-local.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     svc: ftgo-dynamodb-local
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ftgo-dynamodb-local
@@ -18,14 +18,19 @@ metadata:
 spec:
   serviceName: "ftgo-dynamodb"
   replicas: 1
+  selector:
+    matchLabels:
+      app: ftgo-dynamodb-local
+      svc: ftgo-dynamodb-local
   template:
     metadata:
       labels:
+        app: ftgo-dynamodb-local
         svc: ftgo-dynamodb-local
     spec:
       containers:
       - name: ftgo-dynamodb-local
-        image: cnadiminti/dynamodb-local:2017-04-22_beta
+        image: amazon/dynamodb-local:latest
         livenessProbe:
           tcpSocket:
             port: 8000

--- a/deployment/kubernetes/stateful-services/ftgo-kafka-deployment.yml
+++ b/deployment/kubernetes/stateful-services/ftgo-kafka-deployment.yml
@@ -11,22 +11,27 @@ spec:
   selector:
     role: ftgo-kafka
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ftgo-kafka
 spec:
   serviceName: "kafka"
   replicas: 1
+  selector:
+    matchLabels:
+      app: ftgo-kafka
+      role: ftgo-kafka
   template:
     metadata:
       labels:
+        app: ftgo-kafka
         role: ftgo-kafka
     spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: ftgo-kafka
-          image: confluentinc/cp-kafka:5.2.4
+          image: confluentinc/cp-kafka:latest
           env:
             - name: KAFKA_ADVERTISED_LISTENERS
               value: PLAINTEXT://ftgo-kafka:9092

--- a/deployment/kubernetes/stateful-services/ftgo-mysql-deployment.yml
+++ b/deployment/kubernetes/stateful-services/ftgo-mysql-deployment.yml
@@ -12,22 +12,27 @@ spec:
   selector:
     role: ftgo-mysql
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ftgo-mysql
 spec:
   serviceName: "mysql"
   replicas: 1
+  selector:
+    matchLabels:
+      app: ftgo-mysql
+      role: ftgo-mysql
   template:
     metadata:
       labels:
+        app: ftgo-mysql
         role: ftgo-mysql
     spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: ftgo-mysql
-          image: msapatterns/mysql:latest
+          image: mysql:latest
           imagePullPolicy: Always
           args:
               - "--ignore-db-dir=lost+found"

--- a/deployment/kubernetes/stateful-services/ftgo-zookeeper-deployment.yml
+++ b/deployment/kubernetes/stateful-services/ftgo-zookeeper-deployment.yml
@@ -12,22 +12,27 @@ spec:
   selector:
     role: ftgo-zookeeper
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ftgo-zookeeper
 spec:
   serviceName: "zookeeper"
   replicas: 1
+  selector:
+    matchLabels:
+      role: ftgo-zookeeper
+      app: ftgo-zookeeper
   template:
     metadata:
       labels:
+        app: ftgo-zookeeper
         role: ftgo-zookeeper
     spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: ftgo-zookeeper
-          image: confluentinc/cp-zookeeper:5.2.4
+          image: confluentinc/cp-zookeeper:latest
           ports:
               - containerPort: 2181
           env:

--- a/ftgo-accounting-service/src/deployment/kubernetes/ftgo-accounting-service.yml
+++ b/ftgo-accounting-service/src/deployment/kubernetes/ftgo-accounting-service.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     svc: ftgo-accounting-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-accounting-service
@@ -17,12 +17,18 @@ metadata:
     application: ftgo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ftgo-accounting-service
+      svc: ftgo-accounting-service
+      application: ftgo
   strategy:
     rollingUpdate:
       maxUnavailable: 0
   template:
     metadata:
       labels:
+        app: ftgo-accounting-service
         svc: ftgo-accounting-service
         application: ftgo
     spec:

--- a/ftgo-api-gateway/src/deployment/kubernetes/ftgo-api-gateway.yml
+++ b/ftgo-api-gateway/src/deployment/kubernetes/ftgo-api-gateway.yml
@@ -16,7 +16,7 @@ spec:
 #  loadBalancerSourceRanges:
 #    - 88.128.82.195/32
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-api-gateway
@@ -24,12 +24,18 @@ metadata:
     application: ftgo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ftgo-api-gateway
+      svc: ftgo-api-gateway
+      application: ftgo
   strategy:
     rollingUpdate:
       maxUnavailable: 0
   template:
     metadata:
       labels:
+        app: ftgo-api-gateway
         svc: ftgo-api-gateway
         application: ftgo
     spec:

--- a/ftgo-consumer-service/src/deployment/kubernetes/ftgo-consumer-service.yml
+++ b/ftgo-consumer-service/src/deployment/kubernetes/ftgo-consumer-service.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     svc: ftgo-consumer-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-consumer-service
@@ -17,12 +17,18 @@ metadata:
     application: ftgo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ftgo-consumer-service
+      svc: ftgo-consumer-service
+      application: ftgo
   strategy:
     rollingUpdate:
       maxUnavailable: 0
   template:
     metadata:
       labels:
+        app: ftgo-consumer-service
         svc: ftgo-consumer-service
         application: ftgo
     spec:

--- a/ftgo-kitchen-service/src/deployment/kubernetes/ftgo-kitchen-service.yml
+++ b/ftgo-kitchen-service/src/deployment/kubernetes/ftgo-kitchen-service.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     svc: ftgo-kitchen-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-kitchen-service
@@ -17,12 +17,18 @@ metadata:
     application: ftgo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ftgo-kitchen-service
+      svc: ftgo-kitchen-service
+      application: ftgo
   strategy:
     rollingUpdate:
       maxUnavailable: 0
   template:
     metadata:
       labels:
+        app: ftgo-kitchen-service
         svc: ftgo-kitchen-service
         application: ftgo
     spec:

--- a/ftgo-order-history-service/src/deployment/kubernetes/ftgo-order-history-service.yml
+++ b/ftgo-order-history-service/src/deployment/kubernetes/ftgo-order-history-service.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     svc: ftgo-order-history-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-order-history-service
@@ -17,12 +17,18 @@ metadata:
     application: ftgo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ftgo-order-history-service
+      svc: ftgo-order-history-service
+      application: ftgo
   strategy:
     rollingUpdate:
       maxUnavailable: 0
   template:
     metadata:
       labels:
+        app: ftgo-order-history-service
         svc: ftgo-order-history-service
         application: ftgo
     spec:

--- a/ftgo-order-service/src/deployment/kubernetes/ftgo-order-service.yml
+++ b/ftgo-order-service/src/deployment/kubernetes/ftgo-order-service.yml
@@ -17,7 +17,7 @@ spec:
   selector:
     svc: ftgo-order-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-order-service
@@ -25,12 +25,18 @@ metadata:
     application: ftgo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ftgo-order-service
+      svc: ftgo-order-service
+      application: ftgo
   strategy:
     rollingUpdate:
       maxUnavailable: 0
   template:
     metadata:
       labels:
+        app: ftgo-order-service
         svc: ftgo-order-service
         application: ftgo
     spec:

--- a/ftgo-restaurant-service/src/deployment/kubernetes/ftgo-restaurant-service.yml
+++ b/ftgo-restaurant-service/src/deployment/kubernetes/ftgo-restaurant-service.yml
@@ -9,7 +9,7 @@ spec:
   selector:
     svc: ftgo-restaurant-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ftgo-restaurant-service
@@ -18,12 +18,18 @@ metadata:
     svc: ftgo-restaurant-service
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ftgo-restaurant-service
+      svc: ftgo-restaurant-service
+      application: ftgo
   strategy:
     rollingUpdate:
       maxUnavailable: 0
   template:
     metadata:
       labels:
+        app: ftgo-restaurant-service
         svc: ftgo-restaurant-service
         application: ftgo
     spec:


### PR DESCRIPTION
Updated the deprecated K8s `apiVersions` and changed the docker images in K8s yml files to support both x86_64 and Arm64 platforms.