### PR TITLE
 fix pip install error

### DIFF
--- a/dynamodblocal-init/Dockerfile
+++ b/dynamodblocal-init/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:2.7.16-alpine3.9
-RUN pip install awscli --upgrade
+RUN pip install awscli --upgrade --no-build-isolation
 COPY create-dynamodb-tables.sh .
 COPY ftgo-order-history.json .
 COPY wait-for-dynamodblocal.sh .


### PR DESCRIPTION
ERROR: Command errored out with exit status 1: /System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python /Library/Python/2.7/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /var/folders/v1/h87p197d1r37m5vbkx2gj1980000gn/T/tmpARMnUi Check the logs for full command output.